### PR TITLE
Upgrading the collectd mesos plugin to latest commit to master.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 
 default[:collectd_mesos][:repo] = "https://github.com/rayrod2030/collectd-mesos.git"
-default[:collectd_mesos][:revision] = "c57eebaf2b6ae550f51b2d24777a2c4627652e21"
+default[:collectd_mesos][:revision] = "dbd2c6d7d3098b47ea5abf69da421a5c41220789"
 default[:collectd_mesos][:install_dir] = "/opt/collectd-mesos"
 default[:collectd_mesos][:collectd_path] = "/opt/collectd"
 default[:collectd_mesos][:verbose] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,4 +2,4 @@ name             "collectd_mesos"
 license          "MIT"
 description      "Installs and configures the Mesos plugin for collectd"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.1"
+version          "0.0.2"


### PR DESCRIPTION
This is to support the new stats end point in 0.23.x

[Latest commit](https://github.com/rayrod2030/collectd-mesos/commit/dbd2c6d7d3098b47ea5abf69da421a5c41220789)
